### PR TITLE
webaccess: preserve settings is_admin after authenticate (#8110)

### DIFF
--- a/doc/api/hooks_server-side.adoc
+++ b/doc/api/hooks_server-side.adoc
@@ -519,7 +519,7 @@ authnFailure function unless falling back to HTTP basic authentication is
 appropriate upon authentication failure.
 
 This hook is only called if either the `requireAuthentication` setting is true
-or the request is for an `/admin` page.
+or the request is for `/admin-auth` (admin login / session verification).
 
 Calling the provided callback with `[true]` or `[false]` will cause
 authentication to succeed or fail, respectively. Calling the callback with `[]`

--- a/doc/api/hooks_server-side.md
+++ b/doc/api/hooks_server-side.md
@@ -514,7 +514,7 @@ authnFailure function unless falling back to HTTP basic authentication is
 appropriate upon authentication failure.
 
 This hook is only called if either the `requireAuthentication` setting is true
-or the request is for an `/admin` page.
+or the request is for `/admin-auth` (admin login / session verification).
 
 Calling the provided callback with `[true]` or `[false]` will cause
 authentication to succeed or fail, respectively. Calling the callback with `[]`

--- a/src/node/hooks/express/webaccess.ts
+++ b/src/node/hooks/express/webaccess.ts
@@ -179,6 +179,14 @@ const checkAccess = async (req:any, res:any, next: Function) => {
   // user, or a privilege/identity change such as non-admin -> admin), which is
   // the point at which the session id must be rotated (see below).
   const prevUser = req.session != null ? req.session.user : null;
+  // Snapshot is_admin flags before authenticate plugins run. Plugins such as
+  // ep_hash_auth's hash_dir path replace settings.users[username] on success
+  // and can drop a pre-declared is_admin: true (issue #8110), which then fails
+  // the /admin-auth/ authorize check with 403. Restore those flags below.
+  const preAuthAdminUsers = new Set(
+      Object.entries(settings.users as Record<string, {is_admin?: boolean} | null | undefined>)
+          .filter(([, user]) => user != null && !!user.is_admin)
+          .map(([username]) => username));
   // If the HTTP basic auth header is present, extract the username and password so it can be given
   // to authn plugins.
   const httpBasicAuth = req.headers.authorization && req.headers.authorization.startsWith('Basic ');
@@ -226,6 +234,15 @@ const checkAccess = async (req:any, res:any, next: Function) => {
   if (req.session.user == null) {
     httpLogger.error('authenticate hook failed to add user settings to session');
     return res.status(500).send('Internal Server Error');
+  }
+  // Restore is_admin when a settings-declared admin was authenticated by a
+  // plugin that rebuilt the user object without carrying the flag forward.
+  const authedUsername = req.session.user.username;
+  if (authedUsername && preAuthAdminUsers.has(authedUsername) && !req.session.user.is_admin) {
+    req.session.user.is_admin = true;
+    if (settings.users[authedUsername] != null) {
+      settings.users[authedUsername].is_admin = true;
+    }
   }
   // Session fixation defense (GHSA-73h9-c5xp-gfg4): rotate the session id
   // whenever authentication changed the principal — an anonymous session

--- a/src/tests/backend/specs/webaccess.ts
+++ b/src/tests/backend/specs/webaccess.ts
@@ -375,6 +375,35 @@ describe(__filename, function () {
         await agent.get('/').expect(500);
         assert.deepEqual(callOrder, ['preAuthorize_0', 'preAuthorize_1', 'authenticate_0']);
       });
+
+      // Regression for https://github.com/ether/etherpad/issues/8110 —
+      // ep_hash_auth (hash_dir path) authenticates by replacing
+      // settings.users[username] and can drop a pre-declared is_admin flag.
+      // /admin-auth/ must still admit the user when settings said they were admin.
+      it('POST /admin-auth/ invokes authenticate and preserves settings is_admin (#8110)',
+          async function () {
+            settings.requireAuthentication = false;
+            settings.users = {
+              // Classic ep_hash_auth setup: admin declared in settings, credentials
+              // supplied by the authenticate plugin (no plaintext password here).
+              hashadmin: {is_admin: true},
+            };
+            let authenticateCalled = false;
+            plugins.hooks.authenticate = [makeHook('authenticate',
+                (hookName: string, context: any, cb: Function) => {
+                  authenticateCalled = true;
+                  assert.equal(context.username, 'hashadmin');
+                  assert.equal(context.password, 'secret');
+                  // Mimic ep_hash_auth hash_dir success: rebuild the user object
+                  // without carrying is_admin forward.
+                  settings.users.hashadmin = {username: 'hashadmin', is_admin: false};
+                  context.req.session.user = settings.users.hashadmin;
+                  return cb([true]);
+                })];
+            await agent.post('/admin-auth/').auth('hashadmin', 'secret').expect(200);
+            assert.equal(authenticateCalled, true);
+            assert.equal(settings.users.hashadmin.is_admin, true);
+          });
     });
 
     describe('authorize', function () {


### PR DESCRIPTION
## Summary
- Fixes [#8110](https://github.com/ether/etherpad/issues/8110): admin login via `/admin-auth/` failed for `ep_hash_auth` users declared with `is_admin: true` but no plaintext `password` (credentials live in `hash_dir`).
- The `authenticate` hook was already invoked for `/admin-auth/`; `ep_hash_auth`'s hash_dir path replaces `settings.users[username]` on success and drops the pre-declared `is_admin` flag, so authorize returned 403.
- Snapshot `is_admin` before `authenticate` runs and restore it on the session (and settings user) when a settings-declared admin authenticates without the flag.

## Test plan
- [x] `NODE_ENV=production npx mocha --import=tsx --timeout 120000 tests/backend/specs/webaccess.ts` (52 passing, including new `#8110` case)
- [ ] With `ep_hash_auth` installed: user in `settings.users` with `is_admin: true` and no `password`, hash file under `hash_dir` → `POST /admin-auth/` with Basic auth returns 200 and admin UI loads