### PR TITLE
Fix:Pads freeze when selecting Italian

### DIFF
--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -395,7 +395,7 @@
 	"pad.savedrevs.timeslider": "Puoi vedere le versioni salvate visitando la cronologia",
 	"pad.userlist.entername": "Inserisci il tuo nome",
 	"pad.userlist.unnamed": "senza nome",
-	"pad.userlist.onlineCount": "{[ plurale(count) uno: {{count}} utente connesso, altro: {{count}} utenti connessi ]}",
+	"pad.userlist.onlineCount": "{[ plural(count) one: {{count}} utente connesso, other: {{count}} utenti connessi ]}",
 	"pad.editbar.clearcolors": "Eliminare i colori degli autori sull'intero documento? Questa azione non può essere annullata",
 	"pad.impexp.importbutton": "Importa ora",
 	"pad.impexp.importing": "Importazione in corso...",


### PR DESCRIPTION
Fix Italian language freeze (#8178)
Problem
Selecting Italian (Italiano) in User Settings caused Etherpad pads to freeze and become unresponsive. Because the language choice is stored in the browser, all pads opened in that browser were affected.
Root cause
The Italian translation for pad.userlist.onlineCount used unsupported localization macro and plural-form names:
"{[ plurale(count) uno: ..., altro: ... ]}"
Etherpad’s localization parser supports the plural macro with one and other forms. The invalid expression was repeatedly processed, resulting in an endless loop.
Changes made
Updated src/locales/it.json:
- "{[ plurale(count) uno: {{count}} utente connesso, altro: {{count}} utenti connessi ]}"
+ "{[ plural(count) one: {{count}} utente connesso, other: {{count}} utenti connessi ]}"
Testing
- Selected Italian in User Settings.
- Opened and edited a pad.
- Confirmed the GUI switches to Italian.
- Confirmed the pad remains responsive and no longer freezes.

Fixes #8178
<img width="1529" height="802" alt="Screenshot 2026-08-29 135121" src="https://github.com/user-attachments/assets/0e6fbd07-01b1-4520-8ca6-903d97708d62" />
